### PR TITLE
fix: modify output message and delete hello command

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -2,29 +2,14 @@
 // Import the module and reference it with the alias vscode in your code below
 const vscode = require('vscode');
 
-// this method is called when your extension is activated
-// your extension is activated the very first time the command is executed
+let outputChannel = vscode.window.createOutputChannel('Casbin');
 
 /**
  * @param {vscode.ExtensionContext} context
  */
 function activate(context) {
-
-	// Use the console to output diagnostic information (console.log) and errors (console.error)
-	// This line of code will only be executed once when your extension is activated
-	console.log('Congratulations, your extension "hello" is now active!');
-
-	// The command has been defined in the package.json file
-	// Now provide the implementation of the command with  registerCommand
-	// The commandId parameter must match the command field in package.json
-	let disposable = vscode.commands.registerCommand('hello.helloWorld', function () {
-		// The code you place here will be executed every time your command is executed
-
-		// Display a message box to the user
-		vscode.window.showInformationMessage('Hello World from hello!');
-	});
-
-	context.subscriptions.push(disposable);
+	console.log('extension "vscode-casbin" is now active!');
+  	outputChannel.appendLine('extension "vscode-casbin" is now active!');
 }
 
 // this method is called when your extension is deactivated


### PR DESCRIPTION
- change output message from `hello` to `"extension "vscode-casbin" is now active!"`
- delete unuseful hello command